### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -15,14 +15,18 @@ assignees: ''
 <!-- Provides the general description of the issue-->
 ## Description
 
+
+## DoD
 <!-- Describes the requirements from the user's point of view-->
-### User requirements:
+### User story:
 
 <!-- Describes any restrictions and requirements from the developer's point of view -->
 ### Dev requirements and restrictions:
 
+
 <!-- The links to UI mocks-->
 ## UI Mocks
+
 
 <!-- Any additional information that can help to close the issue-->
 ## Other useful information

--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -1,0 +1,28 @@
+---
+name: Issue template
+about: Create a new issue for `Woof` project.
+title: ''
+labels: need more discussion
+assignees: ''
+
+---
+
+<!-- This references to the issues that block the current issue-->
+## Depends on tasks:
+- #_issue
+- #_issue
+
+<!-- Provides the general description of the issue-->
+## Description
+
+<!-- Describes the requirements from the user's point of view-->
+### User requirements:
+
+<!-- Describes any restrictions and requirements from the developer's point of view -->
+### Dev requirements and restrictions:
+
+<!-- The links to UI mocks-->
+## UI Mocks
+
+<!-- Any additional information that can help to close the issue-->
+## Other useful information


### PR DESCRIPTION
## Summary
This PR is a part of the work to resolve https://github.com/ios-course/ironfoudation-team-project/issues/39.
Create a template for issues to simplify and organize workflow. 

## UI Mocks (Screenshots)
**When the user presses a new issue button,  he can see the template section**
<img width="1448" alt="Screenshot 2023-05-18 at 15 49 09" src="https://github.com/ios-course/ironfoudation-team-project/assets/32869814/235ad7af-e57d-4cb1-aea4-cd1a9d2315f7">
***
**The template with suggested information and comments will be displayed**
<img width="1448" alt="Screenshot 2023-05-18 at 15 49 24" src="https://github.com/ios-course/ironfoudation-team-project/assets/32869814/2e33eb7c-39ba-44eb-bf22-bcaf53a44dd2">
***
**The result after submitting a new issue**
<img width="1448" alt="Screenshot 2023-05-18 at 15 50 03" src="https://github.com/ios-course/ironfoudation-team-project/assets/32869814/5d64eb34-ebe8-4c0e-8b67-6440c8cbd4e3">


## Changes

- Added file, which contains a template to submit a new issue for the `Woof` project.
- Label `need more discussion` will be assigned automatically.