### PR TITLE
Reuses `FiveStarRatingView` into `GeneralInfoSectionView`

### DIFF
--- a/Woof/Woof/View/OwnerFlow/SitterListView/SitterCardView/GeneralInfoSectionView.swift
+++ b/Woof/Woof/View/OwnerFlow/SitterListView/SitterCardView/GeneralInfoSectionView.swift
@@ -17,7 +17,6 @@ struct GeneralInfoSectionView: View {
                     .bold()
                     .lineLimit(1)
                 FiveStarRatingView(rating: rating)
-                    .foregroundColor(Color.App.purpleDark)
             }
             Spacer()
             VStack {

--- a/Woof/Woof/View/OwnerFlow/SitterListView/SitterCardView/GeneralInfoSectionView.swift
+++ b/Woof/Woof/View/OwnerFlow/SitterListView/SitterCardView/GeneralInfoSectionView.swift
@@ -16,18 +16,8 @@ struct GeneralInfoSectionView: View {
                 Text(fullName)
                     .bold()
                     .lineLimit(1)
-                Group {
-                    if rating == 0 {
-                        Text("not rated")
-                            .font(Font.system(size: AppStyle.FontStyle.footnote.size))
-                    } else {
-                        HStack(spacing: 0) {
-                            ForEach(0..<rating, id: \.self) { _ in
-                                Image(systemName: .IconName.filledStar)
-                            }
-                        }
-                    }
-                }.foregroundColor(Color.App.purpleDark)
+                FiveStarRatingView(rating: rating)
+                    .foregroundColor(Color.App.purpleDark)
             }
             Spacer()
             VStack {


### PR DESCRIPTION
<!-- Add a meaningful description of the changes you made -->
## Summary
This PR is a part of the work to resolve #119.
Reused `FiveStarRatingView` into `GeneralInfoSectionView` to avoid DRY.

<!-- Go through the checklist below to verify that your PR is good and ready for review -->
## Checks to complete
- [x] I've built and run my changes, and no warnings or errors occurred.
- [x] All existing tests passed with my changes.
- [x] My code follows our style guide.
- [x] I've performed a self-review of my code.
- [x] PR's title has a conventional commit style (short and descriptive).
- [x] Every non-private interface is documented properly.
- [x] I've added tests for my code (if it makes sense).
- [x] PR has assignee, reviewers, milestone, it is properly linked to the project and to the issue.
