### PR TITLE
Add ability to change the role using `Logout` button.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add the `SitterInfoCardView` - [#112](https://github.com/ios-course/ironfoudation-team-project/pull/158)
 - Create `PurpleCapsuleOfInfinityWidth` as `ButtonStyle`. Create `LoginView` and apply in the `WoofApp` to display when running the app when the user role is not selected - [#160](https://github.com/ios-course/ironfoudation-team-project/pull/160)
 - Add the `EditSitterInformationView` and the reusable element `TextEditorWithPlaceholder` - [#159](https://github.com/ios-course/ironfoudation-team-project/pull/159)
-- Add ability to change the role using `Logout` button on the `SitterMainTabView` and `OwnerMainTabView` screens - [#167](https://github.com/ios-course/ironfoudation-team-project/pull/167)
+- Add ability to change the user role using `Logout` button on the `SitterMainTabView` and `OwnerMainTabView` screens - [#167](https://github.com/ios-course/ironfoudation-team-project/pull/167)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add the `SitterInfoCardView` - [#112](https://github.com/ios-course/ironfoudation-team-project/pull/158)
 - Create `PurpleCapsuleOfInfinityWidth` as `ButtonStyle`. Create `LoginView` and apply in the `WoofApp` to display when running the app when the user role is not selected - [#160](https://github.com/ios-course/ironfoudation-team-project/pull/160)
 - Add the `EditSitterInformationView` and the reusable element `TextEditorWithPlaceholder` - [#159](https://github.com/ios-course/ironfoudation-team-project/pull/159)
+- Add ability to change the role using `Logout` button on the `SitterMainTabView` and `OwnerMainTabView` screens - [#167](https://github.com/ios-course/ironfoudation-team-project/pull/167)
 
 ### Changed
 

--- a/Woof/Woof.xcodeproj/project.pbxproj
+++ b/Woof/Woof.xcodeproj/project.pbxproj
@@ -646,13 +646,13 @@
 			isa = PBXGroup;
 			children = (
 				FDEE43DF2A386291007DE0A9 /* UserRoleViewModel.swift */,
-				FD14A2A42A277FA400362461 /* OwnerProfileViewModel.swift */,
+				EF95A0492A385FA600E84ACD /* OwnerMainTabViewModel.swift */,
 				EF95A04C2A385FCF00E84ACD /* SitterMainTabViewModel.swift */,
+				FD14A2A42A277FA400362461 /* OwnerProfileViewModel.swift */,
 				FD1FA3C22A0A682E000A3A91 /* SitterCardViewModel.swift */,
 				EF5A7F2E2A14504F00585616 /* DetailPetSitterViewModel.swift */,
 				FD2FA22A2A129CA1002B618B /* SitterListViewModel.swift */,
 				36E97F162A2F42FD00030E3E /* LoginViewModel.swift */,
-				EF95A0492A385FA600E84ACD /* OwnerMainTabViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";

--- a/Woof/Woof/View/OwnerFlow/OwnerMainTabView/OwnerMainTabView.swift
+++ b/Woof/Woof/View/OwnerFlow/OwnerMainTabView/OwnerMainTabView.swift
@@ -5,7 +5,7 @@ import SwiftUI
  This view displays a tab bar with different tabs for managing pet sitters, walkings, and owner profile information.
  */
 struct OwnerMainTabView: View {
-    @State private var selection: Tab = .sitters
+    // MARK: - Internal interface
 
     init() {
         customizeTabBar()
@@ -37,8 +37,45 @@ struct OwnerMainTabView: View {
             .tint(Color.App.purpleDark)
             .navigationTitle(selection.header)
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                NavigationLink(
+                    destination: LoginView()
+                        .navigationBarBackButtonHidden(true),
+                    isActive: $viewModel.isLogoutConfirmed
+                ) {
+                    Button(logoutButtonLabelText) {
+                        viewModel.isAlertShown.toggle()
+                    }
+                }
+            }
+            .foregroundColor(.App.purpleDark)
+
+            .alert(alertTitle, isPresented: $viewModel.isAlertShown) {
+                Button(continueButtonLabelText) {
+                    viewModel.isLogoutConfirmed.toggle()
+                    userRoleViewModel.resetCurrentRole()
+                    dismiss()
+                }
+                Button(
+                    cancelButtonLabelText,
+                    role: .cancel
+                ) { viewModel.isAlertShown.toggle() }
+            }
         }
     }
+
+    // MARK: - Private interface
+
+    @StateObject private var viewModel = OwnerMainTabViewModel()
+    @State private var selection: Tab = .sitters
+
+    @EnvironmentObject private var userRoleViewModel: UserRoleViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    private let logoutButtonLabelText = "Logout"
+    private let continueButtonLabelText = "Continue"
+    private let cancelButtonLabelText = "Cancel"
+    private let alertTitle = "Do you really want to log out?"
 
     /**
      Customizes the appearance of the tab bar.

--- a/Woof/Woof/View/SitterFlow/SitterMainTabView/SitterMainTabView.swift
+++ b/Woof/Woof/View/SitterFlow/SitterMainTabView/SitterMainTabView.swift
@@ -2,16 +2,7 @@ import SwiftUI
 
 /// A view representing the main tab view for the sitter.
 struct SitterMainTabView: View {
-    // MARK: - Private interface
-
-    @State private var selection: Tab = .schedule
-
-    private func customizeTabBar() {
-        let tabBarAppearance = UITabBar.appearance()
-        tabBarAppearance.unselectedItemTintColor = UIColor(Color.App.grayDark)
-    }
-
-    // MARK: - Public interface
+    // MARK: - Internal interface
 
     init() {
         customizeTabBar()
@@ -43,7 +34,49 @@ struct SitterMainTabView: View {
             .tint(Color.App.purpleDark)
             .navigationTitle(selection.header)
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                NavigationLink(
+                    destination: LoginView()
+                        .navigationBarBackButtonHidden(true),
+                    isActive: $viewModel.isLogoutConfirmed
+                ) {
+                    Button(logoutButtonLabelText) {
+                        viewModel.isAlertShown.toggle()
+                    }
+                }
+            }
+            .foregroundColor(.App.purpleDark)
+
+            .alert(alertTitle, isPresented: $viewModel.isAlertShown) {
+                Button(continueButtonLabelText) {
+                    viewModel.isLogoutConfirmed.toggle()
+                    userRoleViewModel.resetCurrentRole()
+                    dismiss()
+                }
+                Button(
+                    cancelButtonLabelText,
+                    role: .cancel
+                ) { viewModel.isAlertShown.toggle() }
+            }
         }
+    }
+
+    // MARK: - Private interface
+
+    @StateObject private var viewModel = SitterMainTabViewModel()
+    @State private var selection: Tab = .schedule
+
+    @EnvironmentObject private var userRoleViewModel: UserRoleViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    private let logoutButtonLabelText = "Logout"
+    private let continueButtonLabelText = "Continue"
+    private let cancelButtonLabelText = "Cancel"
+    private let alertTitle = "Do you really want to log out?"
+
+    private func customizeTabBar() {
+        let tabBarAppearance = UITabBar.appearance()
+        tabBarAppearance.unselectedItemTintColor = UIColor(Color.App.grayDark)
     }
 }
 

--- a/Woof/Woof/ViewModel/OwnerMainTabViewModel.swift
+++ b/Woof/Woof/ViewModel/OwnerMainTabViewModel.swift
@@ -2,8 +2,9 @@ import Foundation
 
 /// The view model for a owner main tab view, responsible for preparing and processing data for the view.
 final class OwnerMainTabViewModel: ObservableObject {
-    /// Resets the current user role in the app to the default value.
-    func resetCurrentRole() {
-        PreferencesHandler.set(userRole: .none)
-    }
+    /// Indicates whether the alert should be shown.
+    @Published var isAlertShown = false
+
+    /// Indicates whether the logout confirmation was obtained.
+    @Published var isLogoutConfirmed = false
 }

--- a/Woof/Woof/ViewModel/SitterMainTabViewModel.swift
+++ b/Woof/Woof/ViewModel/SitterMainTabViewModel.swift
@@ -2,8 +2,10 @@ import Foundation
 
 /// The view model for a pet sitter main tab view, responsible for preparing and processing data for the view.
 final class SitterMainTabViewModel: ObservableObject {
-    /// Resets the current user role in the app to the default value.
-    func resetCurrentRole() {
-        PreferencesHandler.set(userRole: .none)
-    }
+
+    /// Indicates whether the alert should be shown.
+    @Published var isAlertShown = false
+
+    /// Indicates whether the logout confirmation was obtained.
+    @Published var isLogoutConfirmed = false
 }

--- a/Woof/Woof/ViewModel/SitterMainTabViewModel.swift
+++ b/Woof/Woof/ViewModel/SitterMainTabViewModel.swift
@@ -2,7 +2,6 @@ import Foundation
 
 /// The view model for a pet sitter main tab view, responsible for preparing and processing data for the view.
 final class SitterMainTabViewModel: ObservableObject {
-
     /// Indicates whether the alert should be shown.
     @Published var isAlertShown = false
 

--- a/Woof/WoofTests/ViewModel/OwnerMainTabViewModelTests.swift
+++ b/Woof/WoofTests/ViewModel/OwnerMainTabViewModelTests.swift
@@ -1,18 +1,56 @@
 import XCTest
 
 final class OwnerMainTabViewModelTests: XCTestCase {
-    func testResetCurrentRoleMethodExistsInAPI() {
-        OwnerMainTabViewModel().resetCurrentRole()
+    override func setUp() {
+        super.setUp()
+        viewModel = OwnerMainTabViewModel()
     }
 
-    func testResetCurrentRoleChangesUserRoleToNone() {
-        // Given
-        PreferencesHandler.set(userRole: .owner)
+    func testIsAlertShownPropertyExistsInAPI() {
+        _ = viewModel.isAlertShown
+    }
 
-        // When
-        OwnerMainTabViewModel().resetCurrentRole()
+    func testIsAlertShownPropertyReturnsAssignedValue() {
+        // Given // When
+        viewModel.isAlertShown = true
 
         // Then
-        XCTAssertEqual(PreferencesHandler.getUserRole(), Role.none)
+        XCTAssertTrue(viewModel.isAlertShown)
+
+        // Given // When
+        viewModel.isAlertShown = false
+
+        // Then
+        XCTAssertFalse(viewModel.isAlertShown)
     }
+
+    func testIsAlertShownPropertyReturnsFalseByDefault() {
+        XCTAssertFalse(viewModel.isAlertShown)
+    }
+
+    func testIsLogoutConfirmedPropertyExistsInAPI() {
+        _ = viewModel.isLogoutConfirmed
+    }
+
+    func testIsLogoutConfirmedPropertyReturnsAssignedValue() {
+        // Given // When
+        viewModel.isLogoutConfirmed = true
+
+        // Then
+        XCTAssertTrue(viewModel.isLogoutConfirmed)
+
+        // Given // When
+        viewModel.isLogoutConfirmed = false
+
+        // Then
+        XCTAssertFalse(viewModel.isLogoutConfirmed)
+    }
+
+    func testIsLogoutConfirmedPropertyReturnsFalseByDefault() {
+        XCTAssertFalse(viewModel.isLogoutConfirmed)
+    }
+
+    // MARK: - Private interface
+
+    private var viewModel = OwnerMainTabViewModel()
 }

--- a/Woof/WoofTests/ViewModel/SitterMainTabViewModelTests.swift
+++ b/Woof/WoofTests/ViewModel/SitterMainTabViewModelTests.swift
@@ -1,18 +1,56 @@
 import XCTest
 
 final class SitterMainTabViewModelTests: XCTestCase {
-    func testResetCurrentRoleMethodExistsInAPI() {
-        SitterMainTabViewModel().resetCurrentRole()
+    override func setUp() {
+        super.setUp()
+        viewModel = SitterMainTabViewModel()
     }
 
-    func testResetCurrentRoleChangesUserRoleToNone() {
-        // Given
-        PreferencesHandler.set(userRole: .sitter)
+    func testIsAlertShownPropertyExistsInAPI() {
+        _ = viewModel.isAlertShown
+    }
 
-        // When
-        SitterMainTabViewModel().resetCurrentRole()
+    func testIsAlertShownPropertyReturnsAssignedValue() {
+        // Given // When
+        viewModel.isAlertShown = true
 
         // Then
-        XCTAssertEqual(PreferencesHandler.getUserRole(), Role.none)
+        XCTAssertTrue(viewModel.isAlertShown)
+
+        // Given // When
+        viewModel.isAlertShown = false
+
+        // Then
+        XCTAssertFalse(viewModel.isAlertShown)
     }
+
+    func testIsAlertShownPropertyReturnsFalseByDefault() {
+        XCTAssertFalse(viewModel.isAlertShown)
+    }
+
+    func testIsLogoutConfirmedPropertyExistsInAPI() {
+        _ = viewModel.isLogoutConfirmed
+    }
+
+    func testIsLogoutConfirmedPropertyReturnsAssignedValue() {
+        // Given // When
+        viewModel.isLogoutConfirmed = true
+
+        // Then
+        XCTAssertTrue(viewModel.isLogoutConfirmed)
+
+        // Given // When
+        viewModel.isLogoutConfirmed = false
+
+        // Then
+        XCTAssertFalse(viewModel.isLogoutConfirmed)
+    }
+
+    func testIsLogoutConfirmedPropertyReturnsFalseByDefault() {
+        XCTAssertFalse(viewModel.isLogoutConfirmed)
+    }
+
+    // MARK: - Private interface
+
+    private var viewModel = SitterMainTabViewModel()
 }


### PR DESCRIPTION
<!-- Add a meaningful description of the changes you made -->
## Summary
This PR is a part of the work to resolve #78 

## UI Preview 
<img width="374" alt="Screenshot 2023-06-16 at 09 01 18" src="https://github.com/ios-course/ironfoudation-team-project/assets/110284165/8a993fb5-1b58-4763-b752-660b48bcb361">

<!-- Some description of HOW you achieved it. Perhaps give a high-level description of the program flow. 
Did you need to refactor something? What tradeoffs did you take? 
Are there things in here that you’d particularly like people to pay close attention to? -->
## Changes
- Update the file structure in the `ViewModel` folder
- Remove method to reset role in `SitterMainTabViewModel` and `OwnerMainTabViewModel`
- Add for the `SitterMainTabView` and `OwnerMainTabView` views: 
   - toolbar item "Logout" on the navigation bar.
   - alert that shows message "Do you really want to log out?" when the user taps `Logout` button. The alert has two buttons: `Continue` and `Cancel`. 
   - `NavigationLink` that directs to the `SignInView` view when the user taps `Logout` button and confirms his intention with a tap button `Continue`.
   The role of the user in the application preferences is set to `.none` when the alert's `Continue` button is pressed.

<!-- Go through the checklist below to verify that your PR is good and ready for review -->
## Checks to complete
- [x] I've built and run my changes, and no warnings or errors occurred.
- [x] All existing tests passed with my changes.
- [x] My code follows our style guide.
- [x] I've performed a self-review of my code.
- [x] PR's title has a conventional commit style (short and descriptive).
- [x] Every non-private interface is documented properly.
- [x] I've added tests for my code (if it makes sense).
- [x] PR has assignee, reviewers, milestone, it is properly linked to the project and to the issue.
