### PR TITLE
Add scripts to insert an API-key and the salt during the build phase of the `Woof` target.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add `Obfuscator` enum with `reveal(_:_:)` method - [#196](https://github.com/ios-course/ironfoudation-team-project/pull/196) 
 - Add bash script `Obfuscator.sh` - [#197](https://github.com/ios-course/ironfoudation-team-project/pull/197)
 - Add `ProductionEndpoint`, `APIEnvironment` - [#199](https://github.com/ios-course/ironfoudation-team-project/pull/199)
+- Add scripts to insert API-key to the build phase of the `Woof` target - [#202](https://github.com/ios-course/ironfoudation-team-project/pull/202)
 
 ### Changed
 

--- a/Woof/Woof.xcodeproj/project.pbxproj
+++ b/Woof/Woof.xcodeproj/project.pbxproj
@@ -862,7 +862,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FDE0CEB32A00F8390023F784 /* Build configuration list for PBXNativeTarget "Woof" */;
 			buildPhases = (
+				198A7E0B2AA86C6400903FED /* Insert salt and API key */,
 				FDE0CEA12A00F8370023F784 /* Sources */,
+				198A7E0C2AA8819800903FED /* Erase salt and API key */,
 				FDE0CEA22A00F8370023F784 /* Frameworks */,
 				FDE0CEA32A00F8370023F784 /* Resources */,
 				FDE0CEB82A011BA10023F784 /* Swiftlint */,
@@ -951,6 +953,44 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		198A7E0B2AA86C6400903FED /* Insert salt and API key */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Insert salt and API key";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#!/bin/bash\n\nfile_with_obfuscated_key=\"../scripts/obfuscator/api-key\"\nfile_with_salt=\"../scripts/obfuscator/salt\"\nfile_to_insert_key=\"./Woof/NetworkLayer/Endpoint/WoofAppEndpoint+HTTPAPIEndpoint.swift\"\n\nsalt=$(cat \"$file_with_salt\")\nobfuscated_key=$(cat \"$file_with_obfuscated_key\")\n\nsed -i.bak \"s/.*let obfuscatedKey =.*/    private static let obfuscatedKey = \\\"$obfuscated_key\\\"/\" \"$file_to_insert_key\"\nsed -i '' \"s/.*let salt =.*/    private static let salt = \\\"$salt\\\"/\" \"$file_to_insert_key\"\n";
+		};
+		198A7E0C2AA8819800903FED /* Erase salt and API key */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Erase salt and API key";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#!/bin/bash\n\nfile_to_erase_key=\"./Woof/NetworkLayer/Endpoint/WoofAppEndpoint+HTTPAPIEndpoint.swift\"\nbackup_file=\"$file_to_erase_key.bak\"\n\nif [ -f \"$backup_file\" ]; then\n    cp \"$backup_file\" \"$file_to_erase_key\"\n    echo \"Restored the original Swift file from backup.\"\n    rm \"$backup_file\"\nelse\n    echo \"Backup file not found. No changes were made.\"\nfi\n\n";
+		};
 		FD8182292A1F46B800AE1016 /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;


### PR DESCRIPTION
## Summary
This PR is a part of the work to resolve #200.
While the project is built, the `Insert salt and API-key` script reads the files `Scripts/Obfuscator/api-key` and `Scripts/Obfuscator/salt`, create backup of the `WoofAppEndpoint+HTTPAPIEndpoint` file, and writes their content as values of `salt` and `obfuscatedKey` variables. After the compiling source files phase, the `Erase salt and API key` script restore initial state of `WoofAppEndpoint+HTTPAPIEndpoint` file from the backup file and remove the latter.
I tested this feature and suggest seeing how I did it in the [link](https://disk.yandex.com/d/n0XY1LqywdZOeg). 

## Changes
- Add the script `Insert salt and API-key` to the build phase of the `Woof` target.
- Add the script `Erase salt and API-key` to the build phase of the `Woof` target.

## Checks to complete
- [x] The PR title has a conventional commit style (short and descriptive).
- [x] The PR description includes essential information that helps understand the purpose of the changes.
- [x] I've built and run my changes, and no warnings or errors occurred.
- [x] All existing tests passed with my changes.
- [x] My code follows our style guide.
- [x] I've performed a self-review of my code.
- [x] Every non-private interface is documented properly.
- [x] I've added tests for my code (if it makes sense).
- [x] I've updated `CHANGELOG.md` file.
- [x] PR has assignee, reviewers, milestone, it is properly linked to the project and to the issue.
